### PR TITLE
fix: removed the cache imported from functools

### DIFF
--- a/src/graia/broadcast/interfaces/dispatcher.py
+++ b/src/graia/broadcast/interfaces/dispatcher.py
@@ -1,5 +1,5 @@
 import itertools
-from functools import cache, lru_cache, partial
+from functools import lru_cache, partial
 from inspect import isclass, isfunction
 from typing import (TYPE_CHECKING, Any, Dict, Generator, Generic, Iterable,
                     List, Optional, Sequence, TypeVar)


### PR DESCRIPTION
`@functools.cache` is new in Python3.9 and it's not use in this project.