### PR TITLE
Improve performance.

### DIFF
--- a/src/graia/broadcast/__init__.py
+++ b/src/graia/broadcast/__init__.py
@@ -1,7 +1,7 @@
 import asyncio
 import sys
 import traceback
-from typing import Callable, Dict, Generator, Iterable, List, Optional, Set, Type, Union
+from typing import Callable, Dict, Iterable, List, Optional, Set, Type, Union
 
 from graia.broadcast.entities.track_log import TrackLog, TrackLogType
 

--- a/src/graia/broadcast/__init__.py
+++ b/src/graia/broadcast/__init__.py
@@ -29,7 +29,6 @@ from .typing import T_Dispatcher
 from .utilles import (
     Ctx,
     argument_signature,
-    cached_isinstance,
     dispatcher_mixin_handler,
     group_dict,
     printer,
@@ -117,8 +116,8 @@ class Broadcast:
         post_exception_event: bool = True,
         print_exception: bool = True,
     ):
-        is_exectarget = cached_isinstance(target, ExecTarget)
-        is_listener = cached_isinstance(target, Listener)
+        is_exectarget = isinstance(target, ExecTarget)
+        is_listener = isinstance(target, Listener)
         event: Optional[Dispatchable] = self.event_ctx.get(None)
 
         if is_listener:
@@ -231,7 +230,7 @@ class Broadcast:
             if result.__class__ is Force:
                 return result.content
             elif result.__class__ is RemoveMe:
-                if cached_isinstance(target, Listener):
+                if isinstance(target, Listener):
                     if target in self.listeners:
                         self.listeners.pop(self.listeners.index(target))
 
@@ -334,7 +333,7 @@ class Broadcast:
         namespace: Namespace = None,
         decorators: List[Decorator] = [],
     ):
-        if cached_isinstance(event, str):
+        if isinstance(event, str):
             _name = event
             event = self.findEvent(event)  # type: ignore
             if not event:

--- a/src/graia/broadcast/entities/track_log.py
+++ b/src/graia/broadcast/entities/track_log.py
@@ -15,13 +15,24 @@ class TrackLogType(Enum):
     RequirementCrashed = 4
 
 
-T_TrackLogItem = Union[
-    Tuple[Literal[TrackLogType.LookupStart], str, Any, Any],
-    Tuple[Literal[TrackLogType.Continue], str, Any],
-    Tuple[Literal[TrackLogType.Result], str, "T_Dispatcher"],
-    Tuple[Literal[TrackLogType.LookupEnd], str],
-    Tuple[Literal[TrackLogType.RequirementCrashed], str],
-]
+import sys
+
+if sys.version_info >= (3, 8):
+    T_TrackLogItem = Union[
+        Tuple[Literal[TrackLogType.LookupStart], str, Any, Any],
+        Tuple[Literal[TrackLogType.Continue], str, Any],
+        Tuple[Literal[TrackLogType.Result], str, "T_Dispatcher"],
+        Tuple[Literal[TrackLogType.LookupEnd], str],
+        Tuple[Literal[TrackLogType.RequirementCrashed], str],
+    ]
+else:
+    T_TrackLogItem = Union[
+        Tuple[TrackLogType, str, Any, Any],
+        Tuple[TrackLogType, str, Any],
+        Tuple[TrackLogType, str, "T_Dispatcher"],
+        Tuple[TrackLogType, str],
+        Tuple[TrackLogType, str],
+    ]
 
 
 class TrackLog:

--- a/src/graia/broadcast/interfaces/decorator.py
+++ b/src/graia/broadcast/interfaces/decorator.py
@@ -4,7 +4,7 @@ from graia.broadcast.entities.dispatcher import BaseDispatcher
 
 from ..entities.decorator import Decorator
 from ..entities.signatures import Force
-from ..utilles import cached_isinstance, run_always_await_safely
+from ..utilles import run_always_await_safely
 
 if TYPE_CHECKING:
     from graia.broadcast.interfaces.dispatcher import DispatcherInterface
@@ -34,7 +34,7 @@ class DecoratorInterface(BaseDispatcher):
         return self.dispatcher_interface.event
 
     async def catch(self, interface: "DispatcherInterface"):
-        if cached_isinstance(interface.default, Decorator):
+        if isinstance(interface.default, Decorator):
             decorator: Decorator = interface.default
             if not decorator.pre:
                 # 作为 装饰

--- a/src/graia/broadcast/interfaces/dispatcher.py
+++ b/src/graia/broadcast/interfaces/dispatcher.py
@@ -1,5 +1,5 @@
-from itertools import chain
 from functools import lru_cache
+from itertools import chain
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -11,7 +11,6 @@ from typing import (
 )
 
 from graia.broadcast.entities.context import (
-    LF_TEMPLATE,
     ExecutionContext,
     ParameterContext,
 )

--- a/src/graia/broadcast/interfaces/dispatcher.py
+++ b/src/graia/broadcast/interfaces/dispatcher.py
@@ -26,7 +26,7 @@ from graia.broadcast.typing import (
     T_Dispatcher_Callable,
 )
 
-from ..utilles import cached_getattr, run_always_await_safely
+from ..utilles import run_always_await_safely
 
 if TYPE_CHECKING:
     from graia.broadcast import Broadcast
@@ -74,7 +74,7 @@ class DispatcherInterface(Generic[T_Event]):
         result = {}
 
         for name in DEFAULT_LIFECYCLE_NAMES:
-            v = cached_getattr(dispatcher, name, None)
+            v = getattr(dispatcher, name, None)
             if v and v.__func__ not in LIFECYCLE_ABS:
                 result[name] = v
         return result
@@ -88,9 +88,8 @@ class DispatcherInterface(Generic[T_Event]):
         lifecycle_refs = self.execution_contexts[-1].lifecycle_refs
 
         for dispatcher in dispatchers:
-            if (
-                dispatcher.__class__ is not type
-                and not isinstance(dispatcher, BaseDispatcher)
+            if dispatcher.__class__ is not type and not isinstance(
+                dispatcher, BaseDispatcher
             ):
                 continue
 

--- a/src/graia/broadcast/utilles.py
+++ b/src/graia/broadcast/utilles.py
@@ -63,9 +63,6 @@ def group_dict(iterable: Iterable, key_callable: Callable[[Any], Any]):
 cache_size = 4096
 
 
-cached_getattr = lru_cache(cache_size)(getattr)
-
-
 @lru_cache(cache_size)
 def argument_signature(callable_target):
     return [

--- a/src/graia/broadcast/utilles.py
+++ b/src/graia/broadcast/utilles.py
@@ -62,9 +62,7 @@ def group_dict(iterable: Iterable, key_callable: Callable[[Any], Any]):
 
 cache_size = 4096
 
-origin_isinstance = isinstance
 
-cached_isinstance = lru_cache(1024)(isinstance)
 cached_getattr = lru_cache(cache_size)(getattr)
 
 

--- a/src/test.py
+++ b/src/test.py
@@ -17,7 +17,6 @@ import time
 # import objgraph
 # import copy
 import functools
-from graia.broadcast.utilles import cached_getattr
 
 from graia.broadcast.utilles import dispatcher_mixin_handler
 
@@ -97,7 +96,6 @@ except:
 e = time.time()
 n = e - s
 print(f"used {n}, {count/n}o/s")
-print(cached_getattr.cache_info())
 # print(tasks)
 print(listener.maybe_failure)
 print(listener.param_paths)

--- a/src/test.py
+++ b/src/test.py
@@ -17,7 +17,7 @@ import time
 # import objgraph
 # import copy
 import functools
-from graia.broadcast.utilles import cached_isinstance, cached_getattr
+from graia.broadcast.utilles import cached_getattr
 
 from graia.broadcast.utilles import dispatcher_mixin_handler
 
@@ -28,7 +28,7 @@ class TestEvent(Dispatchable):
         async def catch(interface: "DispatcherInterface"):
             if interface.annotation is str:
                 return "1"
-        
+
         @staticmethod
         async def beforeDispatch(interface: "DispatcherInterface"):
             pass
@@ -71,6 +71,7 @@ for _ in range(count):
     tasks.append(broadcast.Executor(listener, dispatchers=mixins))
 
 import yappi
+
 s = time.time()
 
 """
@@ -96,7 +97,6 @@ except:
 e = time.time()
 n = e - s
 print(f"used {n}, {count/n}o/s")
-print(cached_isinstance.cache_info())
 print(cached_getattr.cache_info())
 # print(tasks)
 print(listener.maybe_failure)


### PR DESCRIPTION
也许最近几次的python更新提高了`isinstance`、`getattr`等内置函数的性能，在3.9中没有必要对它们使用cache（甚至没有cache时性能更好）。