### PR TITLE
Lots of changes

### DIFF
--- a/src/graia/broadcast/builtin/decorators.py
+++ b/src/graia/broadcast/builtin/decorators.py
@@ -1,13 +1,12 @@
 import typing
-from typing import Any, Optional
-
-from graia.broadcast.entities.exectarget import ExecTarget
-from graia.broadcast.utilles import dispatcher_mixin_handler
+from typing import Any, Callable, Optional
 
 from ..entities.decorator import Decorator
+from ..entities.exectarget import ExecTarget
 from ..entities.signatures import Force
 from ..exceptions import RequirementCrashed
 from ..interfaces.decorator import DecoratorInterface
+from ..utilles import dispatcher_mixin_handler
 
 
 class Depend(Decorator):
@@ -15,7 +14,7 @@ class Depend(Decorator):
     depend_callable: ExecTarget
     cache: bool = False
 
-    def __init__(self, callable, *, cache=False):
+    def __init__(self, callable: Callable, *, cache=False):
         self.cache = cache
         self.depend_callable = ExecTarget(callable)
 
@@ -29,8 +28,7 @@ class Depend(Decorator):
                 return Force(attempt)
         result = await interface.dispatcher_interface.broadcast.Executor(
             target=self.depend_callable,
-            dispatchers=dispatcher_mixin_handler(interface.event.Dispatcher),  # type: ignore
-            post_exception_event=True,
+            dispatchers=dispatcher_mixin_handler(interface.event.Dispatcher),
         )
 
         if self.cache:
@@ -59,4 +57,4 @@ class OptionalParam(Decorator):
                 )
             )
         except RequirementCrashed:
-            return Force(None)
+            return Force()

--- a/src/graia/broadcast/entities/context.py
+++ b/src/graia/broadcast/entities/context.py
@@ -1,5 +1,4 @@
-import copy
-from typing import Any, Callable, Dict, Iterable, List, TypeVar
+from typing import Any, Callable, Dict, List, TypeVar
 
 from ..typing import DEFAULT_LIFECYCLE_NAMES, T_Dispatcher
 
@@ -19,7 +18,7 @@ class DII_NestableIterable:
         self.iterable = iterable
         self.indexes = [[0, 0]]
 
-    def __iter__(self):
+    def __iter__(self) -> T_Dispatcher:
         dis_set_index, dis_index = self.indexes[-1]
         dis_set_index_offset = dis_set_index + (dis_set_index and 1)
         dis_index_offset = dis_index + (dis_index and 1)
@@ -70,6 +69,3 @@ class ParameterContext:
                 self.name, self.annotation, self.default, self.dispatchers
             )
         )
-
-
-from .event import Dispatchable

--- a/src/graia/broadcast/entities/dispatcher.py
+++ b/src/graia/broadcast/entities/dispatcher.py
@@ -3,7 +3,7 @@ from types import TracebackType
 from typing import TYPE_CHECKING, List, Optional
 
 if TYPE_CHECKING:
-    from graia.broadcast.interfaces.dispatcher import DispatcherInterface
+    from ..interfaces.dispatcher import DispatcherInterface
 
 
 class BaseDispatcher(metaclass=ABCMeta):

--- a/src/graia/broadcast/entities/dispatcher.py
+++ b/src/graia/broadcast/entities/dispatcher.py
@@ -1,6 +1,6 @@
 from abc import ABCMeta, abstractmethod
 from types import TracebackType
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, List, Optional, Type
 
 if TYPE_CHECKING:
     from ..interfaces.dispatcher import DispatcherInterface
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
 class BaseDispatcher(metaclass=ABCMeta):
     """所有非单函数型 Dispatcher 的基类, 用于为参数解析提供可扩展的支持."""
 
-    mixin: List["BaseDispatcher"]
+    mixin: List["BaseDispatcher", Type["BaseDispatcher"]]
     """声明该 Dispatcher 所包含的来自其他 Dispatcher 提供的参数解析支持,
     若某参数该 Dispatcher 无法解析, 将跳转到该列表中并交由其中的 Dispatcher 进行解析,
     该列表中的 Dispatcher 全部被调用过且都不返回一有效值时才会将解析权交由其他的 Dispatcher.

--- a/src/graia/broadcast/entities/event.py
+++ b/src/graia/broadcast/entities/event.py
@@ -1,11 +1,10 @@
-from typing import TYPE_CHECKING, Type
+from typing import Type
 
-if TYPE_CHECKING:
-    from .dispatcher import BaseDispatcher
+from .dispatcher import BaseDispatcher
 
 
 class Dispatchable:
-    Dispatcher: Type["BaseDispatcher"]
+    Dispatcher: Type[BaseDispatcher]
 
 
 BaseEvent = Dispatchable

--- a/src/graia/broadcast/entities/listener.py
+++ b/src/graia/broadcast/entities/listener.py
@@ -1,12 +1,10 @@
-from typing import TYPE_CHECKING, Callable, List, Type
+from typing import Callable, List, Type
 
 from .decorator import Decorator
 from .event import Dispatchable
 from .exectarget import ExecTarget
 from .namespace import Namespace
-
-if TYPE_CHECKING:
-    from graia.broadcast.typing import T_Dispatcher
+from ..typing import T_Dispatcher
 
 
 class Listener(ExecTarget):
@@ -19,7 +17,7 @@ class Listener(ExecTarget):
         callable: Callable,
         namespace: Namespace,
         listening_events: List[Type[Dispatchable]],
-        inline_dispatchers: List["T_Dispatcher"] = None,
+        inline_dispatchers: List[T_Dispatcher] = None,
         decorators: List[Decorator] = None,
         priority: int = 16,
     ) -> None:

--- a/src/graia/broadcast/entities/signatures.py
+++ b/src/graia/broadcast/entities/signatures.py
@@ -6,7 +6,7 @@ class ObjectContainer:
 
     def __init__(self, content: Union["ObjectContainer", Any] = None):
         if content.__class__ is self.__class__:
-            content = content.target  # type: ignore
+            content = content.target
         self.target = content
 
 

--- a/src/graia/broadcast/entities/track_log.py
+++ b/src/graia/broadcast/entities/track_log.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any, List, Literal, Tuple, Union
 
 if TYPE_CHECKING:
-    from graia.broadcast.typing import T_Dispatcher
+    from ..typing import T_Dispatcher
 
 
 class TrackLogType(Enum):

--- a/src/graia/broadcast/interfaces/decorator.py
+++ b/src/graia/broadcast/interfaces/decorator.py
@@ -1,13 +1,12 @@
 from typing import TYPE_CHECKING, Any, Dict
 
-from graia.broadcast.entities.dispatcher import BaseDispatcher
-
 from ..entities.decorator import Decorator
+from ..entities.dispatcher import BaseDispatcher
 from ..entities.signatures import Force
 from ..utilles import cached_isinstance, run_always_await_safely
 
 if TYPE_CHECKING:
-    from graia.broadcast.interfaces.dispatcher import DispatcherInterface
+    from ..interfaces.dispatcher import DispatcherInterface
 
 
 class DecoratorInterface(BaseDispatcher):

--- a/src/graia/broadcast/interrupt/__init__.py
+++ b/src/graia/broadcast/interrupt/__init__.py
@@ -1,15 +1,13 @@
-import asyncio
-from asyncio.futures import Future
-from typing import Any, Optional, Type, Union
+from asyncio import Future, get_running_loop
+from typing import Optional, Type, Union
 
-from graia.broadcast import Broadcast
-from graia.broadcast.entities.event import Dispatchable
-from graia.broadcast.entities.exectarget import ExecTarget
-from graia.broadcast.entities.signatures import RemoveMe
-from graia.broadcast.exceptions import PropagationCancelled
-from graia.broadcast.priority import Priority
-from graia.broadcast.utilles import dispatcher_mixin_handler
-
+from .. import Broadcast
+from ..entities.event import Dispatchable
+from ..entities.exectarget import ExecTarget
+from ..entities.signatures import RemoveMe
+from ..exceptions import PropagationCancelled
+from ..priority import Priority
+from ..utilles import dispatcher_mixin_handler
 from .waiter import Waiter
 
 
@@ -41,7 +39,7 @@ class InterruptControl:
         Returns:
             Any: 通常这个值由中断本身定义并返回.
         """
-        future = asyncio.get_running_loop().create_future()
+        future = get_running_loop().create_future()
 
         listeners = set()
         for event_type in waiter.listening_events:
@@ -74,7 +72,7 @@ class InterruptControl:
                     inline_dispatchers=waiter.using_dispatchers,
                     decorators=waiter.using_decorators,
                 ),
-                dispatchers=dispatcher_mixin_handler(event.Dispatcher),  # type: ignore
+                dispatchers=dispatcher_mixin_handler(event.Dispatcher),
             )
 
             if result is not None:

--- a/src/graia/broadcast/interrupt/waiter.py
+++ b/src/graia/broadcast/interrupt/waiter.py
@@ -1,8 +1,7 @@
 from abc import ABCMeta, abstractmethod
 from typing import Any, List, Type
 
-from graia.broadcast.entities.decorator import Decorator
-
+from ..entities.decorator import Decorator
 from ..entities.event import Dispatchable
 from ..typing import T_Dispatcher
 
@@ -28,7 +27,7 @@ class Waiter(metaclass=ABCMeta):
 
         return type(  # type: ignore
             "AbstractWaiter",
-            (cls,),  # type: ignore
+            (cls,),
             {
                 "listening_events": listening_events,
                 "using_dispatchers": using_dispatchers,

--- a/src/graia/broadcast/utilles.py
+++ b/src/graia/broadcast/utilles.py
@@ -46,7 +46,7 @@ class Ctx(Generic[T]):
         self.reset(token)
 
 
-def printer(value):
+def printer(value: Any):
     print(value)
     return value
 
@@ -69,12 +69,12 @@ cached_getattr = lru_cache(cache_size)(getattr)
 
 
 @lru_cache(cache_size)
-def argument_signature(callable_target):
+def argument_signature(callable_target: Callable):
     return [
         (
             name,
-            param.annotation if param.annotation != inspect._empty else None,  # type: ignore
-            param.default if param.default != inspect._empty else None,  # type: ignore
+            param.annotation if param.annotation != inspect.Signature.empty else None,
+            param.default if param.default != inspect.Signature.empty else None,
         )
         for name, param in dict(inspect.signature(callable_target).parameters).items()
     ]
@@ -108,5 +108,5 @@ def dispatcher_mixin_handler(dispatcher: Union[Type[BaseDispatcher], BaseDispatc
     return result
 
 
-## NestableIterable impl migrated to:
-## > https://gist.github.com/GreyElaina/f9a5f998ec1c3fc7bddb811ce046d0ca
+# NestableIterable impl migrated to:
+# > https://gist.github.com/GreyElaina/f9a5f998ec1c3fc7bddb811ce046d0ca


### PR DESCRIPTION
- 全部做了一遍优化导入和代码格式化

- 所有内部import改为统一使用相对导入（编辑器会将绝对导入推断为pip安装的库，isort等import排序插件也会把相对和绝对导入分开排序，在pip没有安装此库时，甚至会提示报错，不利于开发，即使运行时相对与绝对导入没有区别）

- 所有可以不使用字符串的注释都改成了类型本身，不会导致循环引用的import都移出了`if TYPE_CHECKING:`

- 移除了许多`# type: ignore`，看起来编辑器的类型推断比想象中的智能

- 还有一些性能优化，如将`isinstance`的调用次数减少1/5

