### PR TITLE
feat: make DispatcherInterface[T] covariant

### DIFF
--- a/src/graia/broadcast/interfaces/dispatcher.py
+++ b/src/graia/broadcast/interfaces/dispatcher.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
     from .. import Broadcast
 
 
-T_Event = TypeVar("T_Event", bound=Dispatchable)
+T_Event = TypeVar("T_Event", bound=Dispatchable, covariant=True)
 
 
 class DispatcherInterface(Generic[T_Event]):


### PR DESCRIPTION
this commit allows subclasses use `super` to apply the upper logic without unexpected type check error.